### PR TITLE
Azimuth starting point, azimuth rotation capability and brake capability are stored in the EEPROM

### DIFF
--- a/rotator_settings.h
+++ b/rotator_settings.h
@@ -142,7 +142,7 @@ You can tweak these, but read the online documentation!
 #define BRAKE_ACTIVE_STATE HIGH
 #define BRAKE_INACTIVE_STATE LOW
 
-#define EEPROM_MAGIC_NUMBER 105
+#define EEPROM_MAGIC_NUMBER 106
 #define EEPROM_WRITE_DIRTY_CONFIG_TIME  30  //time in seconds
 
 


### PR DESCRIPTION
- EEPROM magic number set to 106
- \Ix[x][x] - set az starting point
- \I - display the current az starting point
- \Jx[x][x] - set az rotation capability
- \J - display the current az rotation capability
- \Kx - force disable the az brake even if a pin is defined (x: 0 = enable, 1 = disable)
- \K - display the current az brake state
- \Q - Save settings in the EEPROM and restart

Useful to have the same hardware anf firmware for different rotators setups.

The same process could probably be implemented with elevation, despite it is not common to have various different setups.