### PR TITLE
Warning remove

### DIFF
--- a/k3ng_rotator_controller/k3ng_rotator_controller.ino
+++ b/k3ng_rotator_controller/k3ng_rotator_controller.ino
@@ -4778,7 +4778,7 @@ void read_azimuth(byte force_read){
       #endif // FEATURE_AZIMUTH_CORRECTION
       raw_azimuth = raw_azimuth + (configuration.azimuth_offset * HEADING_MULTIPLIER);
       azimuth = raw_azimuth;
-    #endif FEATURE_AZ_POSITION_HMC5883L_USING_JARZEBSKI_LIBRARY
+    #endif // FEATURE_AZ_POSITION_HMC5883L_USING_JARZEBSKI_LIBRARY
 
     #if defined(FEATURE_AZ_POSITION_DFROBOT_QMC5883)
 


### PR DESCRIPTION
Find an warning if I compile and use the JARZEBSKI library for the HMC5883L