### PR TITLE
Update k3ng_rotator_controller.ino

### DIFF
--- a/k3ng_rotator_controller/k3ng_rotator_controller.ino
+++ b/k3ng_rotator_controller/k3ng_rotator_controller.ino
@@ -11848,7 +11848,7 @@ void service_request_queue(){
     control_port->flush();
   #endif // DEBUG_LOOP
 
-  int work_target_raw_azimuth = 0;
+  float work_target_raw_azimuth = 0;
   byte direction_to_go = 0;
   byte within_tolerance_flag = 0;
 


### PR DESCRIPTION
In order to provide correct Azimuth movement for AZIMUTH_TOLERANCE values which are less than 1.0 degrees, I have changed the type of the variable _work_target_raw_azimuth_ from an int to a float