### PR TITLE
Add option to allow configuration saves without keypress

### DIFF
--- a/k3ng_rotator_controller/k3ng_rotator_controller.ino
+++ b/k3ng_rotator_controller/k3ng_rotator_controller.ino
@@ -7127,10 +7127,12 @@ void update_lcd_display(){
 // --------------------------------------------------------------
 #if defined(FEATURE_REMOTE_UNIT_SLAVE) || defined(FEATURE_YAESU_EMULATION) || defined(FEATURE_EASYCOM_EMULATION)
 void get_keystroke(){
-  while (control_port->available() == 0) {
-  }
-  while (control_port->available() > 0)
-    incoming_serial_byte = control_port->read();
+  #ifndef OPTION_SAVE_CONFIGURATION_WITHOUT_WAITING_FOR_KEYSTROKE
+    while (control_port->available() == 0) {
+    }
+    while (control_port->available() > 0)
+      incoming_serial_byte = control_port->read();
+  #endif
 }
 #endif // defined(FEATURE_REMOTE_UNIT_SLAVE) || defined(FEATURE_YAESU_EMULATION) || defined(FEATURE_EASYCOM_EMULATION)
 

--- a/k3ng_rotator_controller/rotator_features.h
+++ b/k3ng_rotator_controller/rotator_features.h
@@ -181,6 +181,7 @@
 // #define OPTION_MORE_SERIAL_CHECKS
 // #define OPTION_STEPPER_MOTOR_USE_TIMER_ONE_INSTEAD_OF_FIVE  
 // #define OPTION_ALLOW_ROTATIONAL_AND_CONFIGURATION_CMDS_AT_BOOT_UP // if disabled, rotational and configuration commands will be ignored on the serial port for the first 10 second after boot up
+// #define OPTION_SAVE_CONFIGURATION_WITHOUT_WAITING_FOR_KEYSTROKE
 
 // #define OPTION_STEPPER_MOTOR_MAX_2_KHZ
 // #define OPTION_STEPPER_MOTOR_MAX_5_KHZ


### PR DESCRIPTION
Add the ability to invoke the Yaesu calibration commands F, F2, O, and O2, to perform the EEPROM write, without waiting for a user keystroke.   Rotor position will be assumed to be at the desired place when invoking the command.